### PR TITLE
Add fallback for missing pbtk parameters

### DIFF
--- a/test_HTTK.R
+++ b/test_HTTK.R
@@ -18,7 +18,15 @@ library(ggplot2)
 chem.cas <- get_chem_id(chem.cas = "80-05-7")$chem.cas
 
 # 2) parameterize & adjust
-params <- parameterize_pbtk(chem.cas = chem.cas, species = "Human", suppress.messages = TRUE)
+use_pbtk <- TRUE
+params <- tryCatch(
+  parameterize_pbtk(chem.cas = chem.cas, species = "Human", suppress.messages = TRUE),
+  error = function(e) {
+    message("parameterize_pbtk failed: ", e$message)
+    use_pbtk <<- FALSE
+    parameterize_1comp(chem.cas = chem.cas, species = "Human", suppress.messages = TRUE)
+  }
+)
 if (is.na(params$Funbound.plasma) || params$Funbound.plasma == 0) params$Funbound.plasma <- 0.03
 if (is.na(params$Clint)           || params$Clint == 0)           params$Clint           <- 1.2
 
@@ -27,15 +35,19 @@ sim1 <- solve_1comp(dose = 10, interval = 24, n.doses = 5, params = params, chem
 plot(sim1, main = "1-Compartment Plasma Concentration")
 
 # 3-B) PBTK model
-sim_pbtk <- solve_pbtk(
-  parameters    = params,
-  days          = 7,
-  daily.dose    = 10,
-  doses.per.day = 1,
-  tsteps        = 2,
-  output.units  = "mg/L"
-)
-plot(sim_pbtk, which = "Cplasma", main = "PBTK Plasma Concentration")
+if (use_pbtk) {
+  sim_pbtk <- solve_pbtk(
+    parameters    = params,
+    days          = 7,
+    daily.dose    = 10,
+    doses.per.day = 1,
+    tsteps        = 2,
+    output.units  = "mg/L"
+  )
+  plot(sim_pbtk, which = "Cplasma", main = "PBTK Plasma Concentration")
+} else {
+  message("Skipping PBTK simulation due to insufficient parameters.")
+}
 
 # 5) Monte Carlo Css: mg/day scenario
 pop       <- httkpop_generate(method = "vi", nsamp = 1000)
@@ -66,18 +78,25 @@ css_tk    <- css_tk * (MW / 1000)
 med_tk    <- median(css_tk)
 
 # 7) IVIVE – 95% AED
-aed95 <- calc_mc_oral_equiv(
-  chem.cas       = chem.cas,
-  conc           = 10,
-  samples        = 1000,
-  which.quantile = 0.95
+aed95 <- tryCatch(
+  calc_mc_oral_equiv(
+    chem.cas       = chem.cas,
+    conc           = 10,
+    samples        = 1000,
+    which.quantile = 0.95
+  ),
+  error = function(e) {
+    message("calc_mc_oral_equiv failed: ", e$message)
+    NA
+  }
 )
 
 # 8) summary & histogram + density
+aed_text <- if (!is.na(aed95)) round(aed95, 3) else "NA"
 cat("\n===== Results Summary =====\n",
     "* Css mg/day median:       ", round(med_mgday, 3), "mg/L\n",
     "* Css TK sampling median:  ", round(med_tk,     3), "mg/L\n",
-    "* 95% AED:                 ", round(aed95,      3), "mg/kg/day\n")
+    "* 95% AED:                 ", aed_text,        "mg/kg/day\n")
 
 df <- data.frame(
   Css      = c(css_mgday, css_tk),


### PR DESCRIPTION
## Summary
- handle errors when parameterizing pbtk by falling back to 1-compartment
- skip pbtk simulation and AED calc when necessary
- show clearer summary when AED calculation fails

## Testing
- `Rscript test_HTTK.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68831b16753883209973390630028325